### PR TITLE
Add Py3 compatibility to common.py

### DIFF
--- a/whaaaaat/prompts/checkbox.py
+++ b/whaaaaat/prompts/checkbox.py
@@ -129,7 +129,6 @@ def question(message, **kwargs):
 
     def get_prompt_tokens(cli):
         tokens = []
-        T = Token
 
         tokens.append((Token.QuestionMark, '?'))
         tokens.append((Token.Question, ' %s ' % message))

--- a/whaaaaat/prompts/checkbox.py
+++ b/whaaaaat/prompts/checkbox.py
@@ -203,7 +203,7 @@ def question(message, **kwargs):
         def _next():
             ic.pointer_index = ((ic.pointer_index + 1) % ic.line_count)
         _next()
-        while isinstance(ic.choices[ic.pointer_index], Separator)or \
+        while isinstance(ic.choices[ic.pointer_index], Separator) or \
                 ic.choices[ic.pointer_index][2]:
             _next()
 
@@ -212,7 +212,7 @@ def question(message, **kwargs):
         def _prev():
             ic.pointer_index = ((ic.pointer_index - 1) % ic.line_count)
         _prev()
-        while isinstance(ic.choices[ic.pointer_index], Separator)or \
+        while isinstance(ic.choices[ic.pointer_index], Separator) or \
                 ic.choices[ic.pointer_index][2]:
             _prev()
 

--- a/whaaaaat/prompts/common.py
+++ b/whaaaaat/prompts/common.py
@@ -3,10 +3,18 @@
 common prompt functionality
 """
 
+import sys
+
 from prompt_toolkit.validation import Validator, ValidationError
 from prompt_toolkit.styles import style_from_dict
 from prompt_toolkit.token import Token
 from prompt_toolkit.mouse_events import MouseEventTypes
+
+
+PY3 = sys.version_info[0] >= 3
+
+if PY3:
+    basestring = str
 
 
 def if_mousedown(handler):


### PR DESCRIPTION
As said [here](https://github.com/finklabs/whaaaaat/pull/2#issuecomment-290246770), it would be better to exercise the two functions in a test, but given that they're currently unused (except one single call site, in checkbox.py), I left that task alone.